### PR TITLE
Fix IIFE for browser-case

### DIFF
--- a/tasks/dot_compile.js
+++ b/tasks/dot_compile.js
@@ -57,7 +57,7 @@
 
     // RequireJS
     if(!opt.requirejs && !opt.node) {
-      js += 'var ' + opt.variable + ' = function(){' + grunt.util.linefeed;
+      js += 'var ' + opt.variable + ' = (function(){' + grunt.util.linefeed;
     }
     if(opt.requirejs && opt.node) {
       js += 'if(typeof define !== "function") {' + grunt.util.linefeed;


### PR DESCRIPTION
The IIFE to attach all templates to the opt.variable in the global namespace does not work, because the function expression is not wrapped in brackets, just a closing bracket. This PR fixes that.
