### PR TITLE
Prevent uri removal as comments

### DIFF
--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -125,7 +125,7 @@ Compiler.prototype.getFileContent = function(filePath) {
   var _this = this, pendingPartialLoads = {};
 
   var content = grunt.file.read(filePath)
-    .replace(/\/\/.*\n/g,'')
+    .replace(/^(?!.*:\/\/$).*\/\/.*/, '')
     .replace(this.loadRegex, function(m, namespace, loadPath, obj) {
       var content = _this.loadPartial(m, filePath, loadPath, obj);
       pendingPartialLoads[namespace] = content;

--- a/test/example/comments.dot
+++ b/test/example/comments.dot
@@ -5,6 +5,9 @@ wklefjowiefj
 */
 
 
+http://
+ftp://
 // wiejijgiorjgiorgjir
 
 <div></div>
+// last line gets stripped

--- a/test/test_dot_compile.js
+++ b/test/test_dot_compile.js
@@ -48,7 +48,11 @@ describe('dot-compile', function() {
   });
   it('should be able to remove comments during compile', function() {
     expect(/\/\*.*?\*\//gm.test(nodeRequirejsTmpl.comments.toString())).to.be.false;
-    expect(/\/\/.*\n/g.test(nodeRequirejsTmpl.comments.toString())).to.be.false;
+    expect(/^\s*\/\/.*/g.test(nodeRequirejsTmpl.comments.toString())).to.be.false;
+  });
+  it('should not remove http & ftp links', function() {
+    expect(/http:\/\//gm.test(nodeRequirejsTmpl.comments.toString())).to.be.true
+    expect(/ftp:\/\//gm.test(nodeRequirejsTmpl.comments.toString())).to.be.true
   });
   it('should be compile partials-in-partials', function() {
     expect(nodeRequirejsTmpl.partials()).to.have.string('can-compile-partial-in-partials');


### PR DESCRIPTION
I believe this fixes the comment stripping.  I also updated the tests to ensure http: & ftp cases work.
