### PR TITLE
Added support for sharing snippets between files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-dot-compiler",
   "description": "Grunt task for compiling doT templates",
-  "version": "0.5.12",
+  "version": "0.5.12-mod",
   "homepage": "https://github.com/tinganho/grunt-dot",
   "author": {
     "name": "Tingan Ho",

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -14,11 +14,12 @@ var grunt = require('grunt')
 
 var Compiler = function(opt) {
   this.opt = _.defaults(opt || {}, {
-    variable  : 'tmpl',
-    node      : false,
-    root      : opt.gruntRoot,
-    requirejs : false,
-    key       : function(filepath) {
+    variable      : 'tmpl',
+    node          : false,
+    root          : opt.gruntRoot,
+    requirejs     : false,
+    shareSnippets : false,
+    key           : function(filepath) {
       return path.basename(filepath, path.extname(filepath));
     }
   });
@@ -152,8 +153,8 @@ Compiler.prototype.getFileContent = function(filePath) {
 
 Compiler.prototype.compileTemplates = function(files) {
 
-  var js = '', _this = this;
-  
+  var js = '', _this = this,
+    def = this.opt.shareSnippets ? {} : null;
 
   // RequireJS
   if(!this.opt.requirejs && !this.opt.node) {
@@ -188,7 +189,7 @@ Compiler.prototype.compileTemplates = function(files) {
 
   files.map(function(filePath) {
     var template = _this.getFileContent(filePath)
-      , fn       = doT.template(template)
+      , fn       = doT.template(template, null, def)
       , key      = _this.opt.key(filePath);
     js += '  tmpl' + "['" + key + "']=" + fn + ';' + grunt.util.linefeed;
   });


### PR DESCRIPTION
Compiler now ignores original dot.js ability to share snippets between multiple files. I've restored this ability in grunt-dot-compiler which is now available through option (turned off by default).
